### PR TITLE
classify inferred_unit as local pragma

### DIFF
--- a/bparser/src/main/java/de/be4/classicalb/core/parser/analysis/pragma/PragmaLocator.java
+++ b/bparser/src/main/java/de/be4/classicalb/core/parser/analysis/pragma/PragmaLocator.java
@@ -33,6 +33,7 @@ public class PragmaLocator extends DepthFirstAdapter {
 		classifiers.put("label", new PrefixClassifier(input,  PPredicate.class));
 		classifiers.put("symbolic", new PrefixClassifier(input, PExpression.class));
 		classifiers.put("unit", new UnitPragmaClassifier(input));
+		classifiers.put("inferred_unit", new UnitPragmaClassifier(input));
 		classifiers.put("conversion", new PrefixClassifier(input, PExpression.class));
 	}
 

--- a/bparser/src/test/java/de/be4/classicalb/core/parser/analysis/pragma/machines/UnitPragmaMachine.java
+++ b/bparser/src/test/java/de/be4/classicalb/core/parser/analysis/pragma/machines/UnitPragmaMachine.java
@@ -1,0 +1,54 @@
+package de.be4.classicalb.core.parser.analysis.pragma.machines;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.be4.classicalb.core.parser.BParser;
+import de.be4.classicalb.core.parser.analysis.prolog.NodeIdAssignment;
+import de.be4.classicalb.core.parser.exceptions.BException;
+import de.be4.classicalb.core.parser.node.Start;
+import de.prob.prolog.output.PrologTermStringOutput;
+
+public class UnitPragmaMachine {
+
+	private static final String PATH = "src/test/resources/pragmas/";
+	private PrologTermStringOutput out;
+	private NodeIdAssignment ids;
+
+	private File machine;
+
+	@Before
+	public void before() {
+		out = new PrologTermStringOutput();
+		ids = new NodeIdAssignment();
+	}
+
+	@Test
+	public void testUnitPragmaMachine() throws IOException, BException {
+		machine = new File(PATH + "UnitPragmaMachine.mch");
+
+		final BParser parser = new BParser(machine.getName());
+		Start start = parser.parseFile(machine, false);
+		start.apply(ids);
+
+		assertEquals(3, parser.getPragmas().size());
+
+		String[] results = {
+				"global_pragma(unit_alias,['AliasName','[1,x,3]','[5,t,6]'],[],-1,1,1,1,44,[start,0,1,0,2])",
+				"pragma(5,unit,['[1,m,1]'],[],-1,5,3,5,22)",
+				"pragma(6,inferred_unit,['[1,x,2]'],[],-1,6,3,6,31)",
+				 };
+
+		for (int i = 0; i < parser.getPragmas().size(); i++) {
+			out = new PrologTermStringOutput();
+			parser.getPragmas().get(i).printProlog(out, ids);
+			assertEquals(results[i], out.toString());
+		}
+
+	}
+}

--- a/bparser/src/test/resources/pragmas/UnitPragmaMachine.mch
+++ b/bparser/src/test/resources/pragmas/UnitPragmaMachine.mch
@@ -1,0 +1,13 @@
+/*@ unit_alias AliasName [1,x,3] [5,t,6] */
+MACHINE m
+
+VARIABLES
+  /*@ unit [1,m,1] */ xx,
+  /*@ inferred_unit [1,x,2] */ yy
+
+INVARIANT xx:NAT & yy:NAT
+
+INITIALISATION xx,yy:=1,1
+
+
+END


### PR DESCRIPTION
Implemented using the locator already used for the "unit" pragma. Needed to be able to re-parse machines exported from the internal representation.
